### PR TITLE
Enhancement by transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # __Diabetes Diary API Remake__
 
-## 버전 : 1.1.6
+## 버전 : 1.1.7
 
 ***
 
 ### 웹 사이트 주소 ###
+**크롬 브라우저 검수가 아직 안되었습니다. 다른 브라우저로 접속해주세요!**
 
 https://www.diabetes-diary.tk/
 
-### 블로그 주소
+### 블로그 주소 
+
+**제가 어떻게 코드를 설계했고 버그를 해결했는 지 확인할 수 있습니다.**
 
 https://velog.io/@dasd412/series/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4
 ***
@@ -75,6 +78,7 @@ https://velog.io/@dasd412/series/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4
 ***
 
 ### 본인 코드 작성 예시 및 설명
++ [1:N 관계 엔티티 save시 update 쿼리가 추가로 발생 및 전파되는 이슈 해결](https://velog.io/@dasd412/1.%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%B0%8F-%EA%B5%AC%EC%A1%B0-%EC%84%A4%EA%B3%84-1N-%EA%B4%80%EA%B3%84-%EC%97%94%ED%8B%B0%ED%8B%B0-save%EC%8B%9C-update-%EC%BF%BC%EB%A6%AC%EA%B0%80-%EC%B6%94%EA%B0%80%EB%A1%9C-%EB%B0%9C%EC%83%9D%ED%95%98%EB%8A%94-%EC%9D%B4%EC%8A%88-%ED%95%B4%EA%B2%B0)
 + [JPA 및 Querydsl 사용 경험 정리](https://github.com/dasd412/interview_note_for_myself/blob/master/JPA/JPA%20%EC%82%AC%EC%9A%A9%20%EA%B2%BD%ED%97%98%20%EC%A0%95%EB%A6%AC.md)
 + [도메인 테스트 코드 작성하기](https://github.com/dasd412/interview_note_for_myself/blob/master/TestCode/%EB%8F%84%EB%A9%94%EC%9D%B8%20%ED%85%8C%EC%8A%A4%ED%8A%B8.md)
 + [컨트롤러 레이어 테스트 코드 작성하기](https://github.com/dasd412/interview_note_for_myself/blob/master/TestCode/%EC%BB%A8%ED%8A%B8%EB%A1%A4%EB%9F%AC%20%ED%85%8C%EC%8A%A4%ED%8A%B8.md)
@@ -82,7 +86,10 @@ https://velog.io/@dasd412/series/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4
 + [스프링 시큐리티 적용하기](https://velog.io/@dasd412/2.%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EB%A7%8C%EB%93%A4%EA%B8%B0)
 + [일지 기능 구현하기](https://velog.io/@dasd412/3.%EA%B8%B0%EB%B3%B8-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-%EC%9D%BC%EC%A7%80-%EC%9E%91%EC%84%B1%ED%95%98%EA%B8%B0)
 + [배포](https://velog.io/@dasd412/4.-%EB%B0%B0%ED%8F%AC%ED%95%98%EA%B8%B0maven-%ED%94%8C%EB%9F%AC%EA%B7%B8%EC%9D%B8-%EC%B6%94%EA%B0%80)
++ [음식 게시판 페이징 처리하기](https://github.com/dasd412/RemakeDiabetesDiaryAPI/issues/48)
++ [Querydsl BooleanBuilder로 중복 코드 제거하기 리팩토링](https://github.com/dasd412/RemakeDiabetesDiaryAPI/issues/51)
 + [JPA batch insert 실험하기](https://velog.io/@dasd412/JPA-Save-%EC%B5%9C%EC%A0%81%ED%99%94-%EC%8B%A4%ED%97%98-batch-insert)
++ [save, update 성능  40% 향상 ](https://velog.io/@dasd412/%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98%EC%9C%BC%EB%A1%9C-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94%ED%95%98%EA%B8%B0)
 
 ***
 ### API end point
@@ -181,7 +188,7 @@ https://velog.io/@dasd412/series/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4
     + 음식 엔티티에 수량 단위 추가 [요구사항 반영]
     + 중복 QueryDSL 코드 BooleanBuilder로 리팩토링. [BooleanBuider를 활용한 동적 쿼리 생성]
     + 프로필 엔티티 추가 및 작성자 엔티티와 1대1 관계 구성
-    + 엔티티 저장 코드 최적화 수행(예정)
+    + 엔티티 저장 및 수정 코드 최적화 수행 [약 40% 향상]
     + 일지 내용 임시 저장 기능 구현하기(예정)
   
 
@@ -229,14 +236,19 @@ https://velog.io/@dasd412/series/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4
 ***
 
 ### 개선 사항
-
-+ 복합키의 장점을 못 살렸음.
 + Nginx 무중단 배포 실패. (아마 elb와 충돌한 것 같다.)
-+ 음식 엔티티 저장 로직의 비효율 개선 필요
-+ 크롬 브라우저 웹 사이트 보안 인증 및 사이트 보안 강화 필요
-+ 도커를 맛봤지만, 어떻게 적용해야 할지 모르겠다.
++ 크롬 브라우저 웹 사이트 검수 및 사이트 보안 강화 필요
++ 도커를 맛봤지만, 어떻게 기존 CI CD 구조에 적용해야 할지 모르겠다.
 ***
 
+### 참고 서적 [사용 용도]
++ 자바 ORM 표준 JPA 프로그래밍 [JPA 엔티티 설계 및 최적화]
++ 데이터베이스 개론 [정규화 적용]
++ 자바로 배우는 리팩토링 입문 [코드 리팩토링]
++ 자바와 JUnit을 활용한 실용주의 단위 테스트 [단위 테스트 작성법]
++ 스타트 스프링 부트 [게시판]
++ 스프링 부트와 AWS로 혼자 구현하는 웹 서비스 [AWS 배포]
+***
 ### 본인 작성이 아닌 것.
 
 + /resources/static/vendor/* [colorLib 저작권 ]
@@ -244,3 +256,4 @@ https://velog.io/@dasd412/series/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4
 + /resources/static/js/calendar/ (calendar.js ,formatter.js, stringBuffer.js) [구글링 코드]
 + src/main/java/com/dasd412/remake/api/controller/security/domain_view/FoodPageMaker [스타트 스프링 부트]
 
+***

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>ReFacDiabetesDiary</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.7-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/dasd412/remake/api/controller/security/domain_rest/SecurityDiaryRestController.java
+++ b/src/main/java/com/dasd412/remake/api/controller/security/domain_rest/SecurityDiaryRestController.java
@@ -1,5 +1,5 @@
 /*
- * @(#)SecurityDiaryRestController.java        1.1.6 2022/3/21
+ * @(#)SecurityDiaryRestController.java        1.1.7 2022/3/23
  *
  * Copyright (c) 2022 YoungJun Yang.
  * ComputerScience, ProgrammingLanguage, Java, Pocheon-si, KOREA
@@ -19,11 +19,9 @@ import com.dasd412.remake.api.domain.diary.writer.Writer;
 import com.dasd412.remake.api.service.domain.FindDiaryService;
 import com.dasd412.remake.api.service.domain.SaveDiaryService;
 import com.dasd412.remake.api.service.domain.UpdateDeleteDiaryService;
-import com.dasd412.remake.api.util.DateStringJoiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -36,7 +34,7 @@ import java.util.stream.Collectors;
  * 로그인한 사용자들이 일지를 "사용" (작성, 수정, 삭제 등...)할 때의 일을 처리하는 RestController
  *
  * @author 양영준
- * @version 1.1.6 2022년 3월 21일
+ * @version 1.1.7 2022년 3월 23일
  */
 @RestController
 public class SecurityDiaryRestController {
@@ -64,7 +62,7 @@ public class SecurityDiaryRestController {
     public ApiResult<SecurityDiaryPostResponseDTO> postDiary(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody @Valid SecurityDiaryPostRequestDTO dto) {
         logger.info("post diary with authenticated user");
 
-        Long diaryId = saveDiaryService.postDiary(principalDetails, dto);
+        Long diaryId = saveDiaryService.postDiaryWithEntities(principalDetails, dto);
 
         return ApiResult.OK(new SecurityDiaryPostResponseDTO(diaryId));
     }
@@ -77,70 +75,10 @@ public class SecurityDiaryRestController {
     @PutMapping("/api/diary/user/diabetes-diary")
     public ApiResult<SecurityDiaryUpdateResponseDTO> updateDiary(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody SecurityDiaryUpdateDTO dto) {
         logger.info("update diabetes diary from browser");
-        logger.info(dto.toString());
 
-        EntityId<Writer, Long> writerLongEntityId = EntityId.of(Writer.class, principalDetails.getWriter().getId());
-        EntityId<DiabetesDiary, Long> diabetesDiaryLongEntityId = EntityId.of(DiabetesDiary.class, dto.getDiaryId());
-        EntityId<Diet, Long> breakFastEntityId = EntityId.of(Diet.class, dto.getBreakFastId());
-        EntityId<Diet, Long> lunchEntityId = EntityId.of(Diet.class, dto.getLunchId());
-        EntityId<Diet, Long> dinnerEntityId = EntityId.of(Diet.class, dto.getDinnerId());
+        Long diaryId= updateDeleteDiaryService.updateDiaryWithEntities(principalDetails,dto);
 
-        /* 혈당 일지 변경 감지 되었으면 수정. */
-        if (dto.isDiaryDirty()) {
-            updateDeleteDiaryService.updateDiary(writerLongEntityId, diabetesDiaryLongEntityId, dto.getFastingPlasmaGlucose(), dto.getRemark());
-        }
-
-        /* 아침 식단 변경 감지 되었으면 수정 */
-        if (dto.isBreakFastDirty()) {
-            updateDeleteDiaryService.updateDiet(writerLongEntityId, diabetesDiaryLongEntityId, breakFastEntityId, EatTime.BreakFast, dto.getBreakFastSugar());
-        }
-
-        /* 점심 식단 변경 감지 되었으면 수정 */
-        if (dto.isLunchDirty()) {
-            updateDeleteDiaryService.updateDiet(writerLongEntityId, diabetesDiaryLongEntityId, lunchEntityId, EatTime.Lunch, dto.getLunchSugar());
-        }
-
-        /* 저녁 식단 변경 감지 되었으면 수정 */
-        if (dto.isDinnerDirty()) {
-            updateDeleteDiaryService.updateDiet(writerLongEntityId, diabetesDiaryLongEntityId, dinnerEntityId, EatTime.Dinner, dto.getDinnerSugar());
-        }
-
-        /* 기존 음식 엔티티 삭제 ( in (id) 벌크 삭제) */
-        List<SecurityFoodForUpdateDTO> allOldFoods = new ArrayList<>();
-        allOldFoods.addAll(dto.getOldBreakFastFoods());
-        allOldFoods.addAll(dto.getOldLunchFoods());
-        allOldFoods.addAll(dto.getOldDinnerFoods());
-
-        if (allOldFoods.size() > 0) {
-            List<EntityId<Food, Long>> foodEntityIds = allOldFoods.stream().map(elem -> EntityId.of(Food.class, elem.getId())).collect(Collectors.toList());
-            updateDeleteDiaryService.bulkDeleteFoods(foodEntityIds);
-        }
-
-        /* 음식 엔티티 새로이 생성 */
-        dto.getNewBreakFastFoods()
-                .forEach(elem -> saveDiaryService.saveFoodAndAmountOfWriterById
-                        (writerLongEntityId,
-                                diabetesDiaryLongEntityId,
-                                breakFastEntityId,
-                                elem.getFoodName(), elem.getAmount(), elem.getAmountUnit()
-                        ));
-
-        dto.getNewLunchFoods()
-                .forEach(elem -> saveDiaryService.saveFoodAndAmountOfWriterById
-                        (writerLongEntityId,
-                                diabetesDiaryLongEntityId,
-                                lunchEntityId,
-                                elem.getFoodName(), elem.getAmount(), elem.getAmountUnit()
-                        ));
-
-        dto.getNewDinnerFoods()
-                .forEach(elem -> saveDiaryService.saveFoodAndAmountOfWriterById
-                        (writerLongEntityId,
-                                diabetesDiaryLongEntityId,
-                                dinnerEntityId,
-                                elem.getFoodName(), elem.getAmount(), elem.getAmountUnit()
-                        ));
-        return ApiResult.OK(new SecurityDiaryUpdateResponseDTO(dinnerEntityId.getId()));
+        return ApiResult.OK(new SecurityDiaryUpdateResponseDTO(diaryId));
     }
 
     /**
@@ -152,6 +90,7 @@ public class SecurityDiaryRestController {
     @DeleteMapping("/api/diary/user/diabetes-diary/{diaryId}")
     public void bulkDeleteDiary(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long diaryId) {
         logger.info("bulk delete Diabetes Diary from browser");
+
         updateDeleteDiaryService.deleteDiary(EntityId.of(Writer.class, principalDetails.getWriter().getId()), EntityId.of(DiabetesDiary.class, diaryId));
     }
 

--- a/src/main/java/com/dasd412/remake/api/controller/security/domain_rest/SecurityDiaryRestController.java
+++ b/src/main/java/com/dasd412/remake/api/controller/security/domain_rest/SecurityDiaryRestController.java
@@ -64,50 +64,7 @@ public class SecurityDiaryRestController {
     public ApiResult<SecurityDiaryPostResponseDTO> postDiary(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody @Valid SecurityDiaryPostRequestDTO dto) {
         logger.info("post diary with authenticated user");
 
-        Long writerId = principalDetails.getWriter().getId();
-
-        /*JSON 직렬화가 LocalDateTime 에는 적용이 안되서 작성한 코드. */
-        DateStringJoiner dateStringJoiner = DateStringJoiner.builder()
-                .year(dto.getYear()).month(dto.getMonth()).day(dto.getDay())
-                .hour(dto.getHour()).minute(dto.getMinute()).second(dto.getSecond())
-                .build();
-
-        LocalDateTime writtenTime = dateStringJoiner.convertLocalDateTime();
-
-        /* 혈당 일지 저장 */
-        DiabetesDiary diary = saveDiaryService.saveDiaryOfWriterById(EntityId.of(Writer.class, writerId), dto.getFastingPlasmaGlucose(), dto.getRemark(), writtenTime);
-
-        Long diaryId = diary.getId();
-
-        /* 아침 점심 저녁 식단 저장 */
-        Diet breakFast = saveDiaryService.saveDietOfWriterById(EntityId.of(Writer.class, writerId), EntityId.of(DiabetesDiary.class, diaryId), EatTime.BreakFast, dto.getBreakFastSugar());
-        Diet lunch = saveDiaryService.saveDietOfWriterById(EntityId.of(Writer.class, writerId), EntityId.of(DiabetesDiary.class, diaryId), EatTime.Lunch, dto.getLunchSugar());
-        Diet dinner = saveDiaryService.saveDietOfWriterById(EntityId.of(Writer.class, writerId), EntityId.of(DiabetesDiary.class, diaryId), EatTime.Dinner, dto.getDinnerSugar());
-
-        /* 아침 음식 저장 */
-        dto.getBreakFastFoods()
-                .forEach(elem -> saveDiaryService.saveFoodAndAmountOfWriterById
-                        (EntityId.of(Writer.class, writerId),
-                                EntityId.of(DiabetesDiary.class, diaryId),
-                                EntityId.of(Diet.class, breakFast.getDietId()),
-                                elem.getFoodName(), elem.getAmount(), elem.getAmountUnit()
-                        ));
-        /* 점심 음식 저장 */
-        dto.getLunchFoods()
-                .forEach(elem -> saveDiaryService.saveFoodAndAmountOfWriterById
-                        (EntityId.of(Writer.class, writerId),
-                                EntityId.of(DiabetesDiary.class, diaryId),
-                                EntityId.of(Diet.class, lunch.getDietId()),
-                                elem.getFoodName(), elem.getAmount(), elem.getAmountUnit()
-                        ));
-        /* 식단 음식 저장 */
-        dto.getDinnerFoods()
-                .forEach(elem -> saveDiaryService.saveFoodAndAmountOfWriterById
-                        (EntityId.of(Writer.class, writerId),
-                                EntityId.of(DiabetesDiary.class, diaryId),
-                                EntityId.of(Diet.class, dinner.getDietId()),
-                                elem.getFoodName(), elem.getAmount(), elem.getAmountUnit()
-                        ));
+        Long diaryId = saveDiaryService.postDiary(principalDetails, dto);
 
         return ApiResult.OK(new SecurityDiaryPostResponseDTO(diaryId));
     }

--- a/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
+++ b/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
@@ -1,5 +1,5 @@
 /*
- * @(#)SaveDiaryService.java        1.1.7 2022/3/22
+ * @(#)SaveDiaryService.java        1.1.7 2022/3/23
  *
  * Copyright (c) 2022 YoungJun Yang.
  * ComputerScience, ProgrammingLanguage, Java, Pocheon-si, KOREA
@@ -40,7 +40,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 저장 로직을 수행하는 서비스 클래스
  *
  * @author 양영준
- * @version 1.1.7 2022년 3월 22일
+ * @version 1.1.7 2022년 3월 23일
  */
 @Service
 public class SaveDiaryService {
@@ -141,7 +141,7 @@ public class SaveDiaryService {
      * @return 작성된 일지의 id
      */
     @Transactional
-    public Long postDiary(PrincipalDetails principalDetails, SecurityDiaryPostRequestDTO dto) {
+    public Long postDiaryWithEntities(PrincipalDetails principalDetails, SecurityDiaryPostRequestDTO dto) {
         logger.info("post diary in service logic");
         checkNotNull(principalDetails, "principalDetails must be provided");
 

--- a/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
+++ b/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
@@ -1,5 +1,5 @@
 /*
- * @(#)SaveDiaryService.java        1.1.1 2022/2/28
+ * @(#)SaveDiaryService.java        1.1.7 2022/3/22
  *
  * Copyright (c) 2022 YoungJun Yang.
  * ComputerScience, ProgrammingLanguage, Java, Pocheon-si, KOREA
@@ -37,7 +37,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 저장 로직을 수행하는 서비스 클래스
  *
  * @author 양영준
- * @version 1.1.1 2022년 2월 28일
+ * @version 1.1.7 2022년 3월 22일
  */
 @Service
 public class SaveDiaryService {
@@ -114,7 +114,19 @@ public class SaveDiaryService {
         return EntityId.of(Food.class, foodId + 1);
     }
 
+    @Transactional
+    public void postDiary() {
 
+    }
+
+    /**
+     * 1.17 버전 부터 [테스트 환경]에서만 사용
+     *
+     * @param name  유저 네임
+     * @param email 이메일
+     * @param role  권한
+     * @return 회원 가입된 작성자
+     */
     @Transactional
     public Writer saveWriter(String name, String email, Role role) {
         logger.info("saveWriter");
@@ -123,6 +135,15 @@ public class SaveDiaryService {
         return writer;
     }
 
+    /**
+     * 1.17 버전 부터 [테스트 환경]에서만 사용
+     *
+     * @param writerEntityId       작성자 id
+     * @param fastingPlasmaGlucose 공복 혈당
+     * @param remark               비고
+     * @param writtenTime          작성시간
+     * @return 작성 완료된 일지
+     */
     @Transactional
     public DiabetesDiary saveDiaryOfWriterById(EntityId<Writer, Long> writerEntityId, int fastingPlasmaGlucose, String remark, LocalDateTime writtenTime) {
         logger.info("saveDiaryOfWriterById");
@@ -135,6 +156,15 @@ public class SaveDiaryService {
         return diary;
     }
 
+    /**
+     * 1.17 버전 부터 [테스트 환경]에서만 사용
+     *
+     * @param writerEntityId 작성자 id
+     * @param diaryEntityId  일지 id
+     * @param eatTime        식사 시간
+     * @param bloodSugar     혈당
+     * @return 작성 완료된 식사
+     */
     @Transactional
     public Diet saveDietOfWriterById(EntityId<Writer, Long> writerEntityId, EntityId<DiabetesDiary, Long> diaryEntityId, EatTime eatTime, int bloodSugar) {
         logger.info("saveDietOfWriterById");
@@ -149,6 +179,15 @@ public class SaveDiaryService {
         return diet;
     }
 
+    /**
+     * 1.17 버전 부터 [테스트 환경]에서만 사용
+     *
+     * @param writerEntityId 작성자 id
+     * @param diaryEntityId  일지 id
+     * @param dietEntityId   식사 id
+     * @param foodName       음식 이름
+     * @return 작성된 음식
+     */
     @Transactional
     public Food saveFoodOfWriterById(EntityId<Writer, Long> writerEntityId, EntityId<DiabetesDiary, Long> diaryEntityId, EntityId<Diet, Long> dietEntityId, String foodName) {
         logger.info("saveFoodOfWriterById");
@@ -164,6 +203,16 @@ public class SaveDiaryService {
         return food;
     }
 
+    /**
+     * 1.17 버전 부터 [테스트 환경]에서만 사용
+     *
+     * @param writerEntityId 작성자 id
+     * @param diaryEntityId  일지 id
+     * @param dietEntityId   식사 id
+     * @param foodName       음식 이름
+     * @param amount         음식 양
+     * @param amountUnit     음식 단위
+     */
     @Transactional
     public void saveFoodAndAmountOfWriterById(EntityId<Writer, Long> writerEntityId, EntityId<DiabetesDiary, Long> diaryEntityId, EntityId<Diet, Long> dietEntityId, String foodName, double amount, AmountUnit amountUnit) {
         logger.info("saveFoodAndAmountOfWriterById");
@@ -178,6 +227,11 @@ public class SaveDiaryService {
         writerRepository.save(writer);
     }
 
+    /**
+     * @param writerEntityId 작성자 id
+     * @param phase          당뇨 단계
+     * @return 작성자의 생성된 프로필
+     */
     @Transactional
     public Profile makeProfile(EntityId<Writer, Long> writerEntityId, DiabetesPhase phase) {
         logger.info("make profile");

--- a/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
+++ b/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
@@ -8,6 +8,8 @@
 
 package com.dasd412.remake.api.service.domain;
 
+import com.dasd412.remake.api.config.security.auth.PrincipalDetails;
+import com.dasd412.remake.api.controller.security.domain_rest.dto.diary.SecurityDiaryPostRequestDTO;
 import com.dasd412.remake.api.domain.diary.EntityId;
 import com.dasd412.remake.api.domain.diary.diabetesDiary.DiabetesDiary;
 import com.dasd412.remake.api.domain.diary.diabetesDiary.DiaryRepository;
@@ -23,6 +25,7 @@ import com.dasd412.remake.api.domain.diary.profile.ProfileRepository;
 import com.dasd412.remake.api.domain.diary.writer.Role;
 import com.dasd412.remake.api.domain.diary.writer.Writer;
 import com.dasd412.remake.api.domain.diary.writer.WriterRepository;
+import com.dasd412.remake.api.util.DateStringJoiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -114,18 +117,86 @@ public class SaveDiaryService {
         return EntityId.of(Food.class, foodId + 1);
     }
 
-    @Transactional
-    public void postDiary() {
+    /**
+     * JSON 직렬화가 LocalDateTime 에는 적용이 안되서 작성한 헬프 메서드.
+     *
+     * @param dto 작성된 일지 정보 (일지, 식단, 음식 모두 포함)
+     * @return String => LocalDateTime
+     */
+    private LocalDateTime convertStringToLocalDateTime(SecurityDiaryPostRequestDTO dto) {
+        DateStringJoiner dateStringJoiner = DateStringJoiner.builder()
+                .year(dto.getYear()).month(dto.getMonth()).day(dto.getDay())
+                .hour(dto.getHour()).minute(dto.getMinute()).second(dto.getSecond())
+                .build();
 
+        return dateStringJoiner.convertLocalDateTime();
+    }
+
+    /**
+     * 1.17 버전부터 일지 저장에 쓰이는 서비스 로직
+     * 트랜잭션 하나에 넣어서 처리 (트랜잭션 오버헤드 줄이기 위함)
+     *
+     * @param principalDetails 로그인된 유저의 세션 정보
+     * @param dto              컨트롤러에서 받아온 일지 저장용 dto
+     * @return 작성된 일지의 id
+     */
+    @Transactional
+    public Long postDiary(PrincipalDetails principalDetails, SecurityDiaryPostRequestDTO dto) {
+        logger.info("post diary in service logic");
+        checkNotNull(principalDetails, "principalDetails must be provided");
+
+        /* 0. 현재 세션에 담긴 사용자 정보 판별 */
+        Writer writer = writerRepository.findById(principalDetails.getWriter().getId()).orElseThrow(() -> new NoResultException("작성자가 없습니다."));
+
+        /* 2-1. LocalDateTime JSON 직렬화 */
+        LocalDateTime writtenTime = convertStringToLocalDateTime(dto);
+
+        /* 2-2. 혈당 일지 저장 */
+        DiabetesDiary diary = new DiabetesDiary(getNextIdOfDiary(), writer, dto.getFastingPlasmaGlucose(), dto.getRemark(), writtenTime);
+        writer.addDiary(diary);
+
+        /* 3. 아침 점심 저녁 식사 저장 */
+
+        Diet breakFast = new Diet(getNextIdOfDiet(), diary, EatTime.BreakFast, dto.getBreakFastSugar());
+        diary.addDiet(breakFast);
+
+        Diet lunch = new Diet(getNextIdOfDiet(), diary, EatTime.Lunch, dto.getLunchSugar());
+        diary.addDiet(lunch);
+
+        Diet dinner = new Diet(getNextIdOfDiet(), diary, EatTime.Dinner, dto.getDinnerSugar());
+        diary.addDiet(dinner);
+
+        /* 4-1. 아침 음식 저장 */
+        dto.getBreakFastFoods().forEach(elem -> {
+            Food food = new Food(getNextIdOfFood(), breakFast, elem.getFoodName(), elem.getAmount(), elem.getAmountUnit());
+            breakFast.addFood(food);
+        });
+
+        /* 4-2. 점심 음식 저장 */
+        dto.getLunchFoods().forEach(elem -> {
+            Food food = new Food(getNextIdOfFood(), lunch, elem.getFoodName(), elem.getAmount(), elem.getAmountUnit());
+            lunch.addFood(food);
+        });
+
+        /* 4-3. 저녁 음식 저장 */
+        dto.getDinnerFoods().forEach(elem -> {
+            Food food = new Food(getNextIdOfFood(), dinner, elem.getFoodName(), elem.getAmount(), elem.getAmountUnit());
+            dinner.addFood(food);
+        });
+
+        writerRepository.save(writer);
+
+        return diary.getId();
     }
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     * @deprecated
+     *
      * @param name  유저 네임
      * @param email 이메일
      * @param role  권한
      * @return 회원 가입된 작성자
+     * @deprecated
      */
     @Transactional
     public Writer saveWriter(String name, String email, Role role) {
@@ -137,12 +208,13 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     * @deprecated
+     *
      * @param writerEntityId       작성자 id
      * @param fastingPlasmaGlucose 공복 혈당
      * @param remark               비고
      * @param writtenTime          작성시간
      * @return 작성 완료된 일지
+     * @deprecated
      */
     @Transactional
     public DiabetesDiary saveDiaryOfWriterById(EntityId<Writer, Long> writerEntityId, int fastingPlasmaGlucose, String remark, LocalDateTime writtenTime) {
@@ -158,12 +230,13 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     * @deprecated
+     *
      * @param writerEntityId 작성자 id
      * @param diaryEntityId  일지 id
      * @param eatTime        식사 시간
      * @param bloodSugar     혈당
      * @return 작성 완료된 식사
+     * @deprecated
      */
     @Transactional
     public Diet saveDietOfWriterById(EntityId<Writer, Long> writerEntityId, EntityId<DiabetesDiary, Long> diaryEntityId, EatTime eatTime, int bloodSugar) {
@@ -181,12 +254,13 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     * @deprecated
+     *
      * @param writerEntityId 작성자 id
      * @param diaryEntityId  일지 id
      * @param dietEntityId   식사 id
      * @param foodName       음식 이름
      * @return 작성된 음식
+     * @deprecated
      */
     @Transactional
     public Food saveFoodOfWriterById(EntityId<Writer, Long> writerEntityId, EntityId<DiabetesDiary, Long> diaryEntityId, EntityId<Diet, Long> dietEntityId, String foodName) {
@@ -205,13 +279,14 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     * @deprecated
+     *
      * @param writerEntityId 작성자 id
      * @param diaryEntityId  일지 id
      * @param dietEntityId   식사 id
      * @param foodName       음식 이름
      * @param amount         음식 양
      * @param amountUnit     음식 단위
+     * @deprecated
      */
     @Transactional
     public void saveFoodAndAmountOfWriterById(EntityId<Writer, Long> writerEntityId, EntityId<DiabetesDiary, Long> diaryEntityId, EntityId<Diet, Long> dietEntityId, String foodName, double amount, AmountUnit amountUnit) {

--- a/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
+++ b/src/main/java/com/dasd412/remake/api/service/domain/SaveDiaryService.java
@@ -121,7 +121,7 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     *
+     * @deprecated
      * @param name  유저 네임
      * @param email 이메일
      * @param role  권한
@@ -137,7 +137,7 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     *
+     * @deprecated
      * @param writerEntityId       작성자 id
      * @param fastingPlasmaGlucose 공복 혈당
      * @param remark               비고
@@ -158,7 +158,7 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     *
+     * @deprecated
      * @param writerEntityId 작성자 id
      * @param diaryEntityId  일지 id
      * @param eatTime        식사 시간
@@ -181,7 +181,7 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     *
+     * @deprecated
      * @param writerEntityId 작성자 id
      * @param diaryEntityId  일지 id
      * @param dietEntityId   식사 id
@@ -205,7 +205,7 @@ public class SaveDiaryService {
 
     /**
      * 1.17 버전 부터 [테스트 환경]에서만 사용
-     *
+     * @deprecated
      * @param writerEntityId 작성자 id
      * @param diaryEntityId  일지 id
      * @param dietEntityId   식사 id

--- a/src/main/java/com/dasd412/remake/api/service/domain/UpdateDeleteDiaryService.java
+++ b/src/main/java/com/dasd412/remake/api/service/domain/UpdateDeleteDiaryService.java
@@ -1,5 +1,5 @@
 /*
- * @(#)UpdateDeleteDiaryService.java        1.1.1 2022/2/28
+ * @(#)UpdateDeleteDiaryService.java        1.1.7 2022/3/23
  *
  * Copyright (c) 2022 YoungJun Yang.
  * ComputerScience, ProgrammingLanguage, Java, Pocheon-si, KOREA
@@ -8,6 +8,9 @@
 
 package com.dasd412.remake.api.service.domain;
 
+import com.dasd412.remake.api.config.security.auth.PrincipalDetails;
+import com.dasd412.remake.api.controller.security.domain_rest.dto.diary.SecurityDiaryUpdateDTO;
+import com.dasd412.remake.api.controller.security.domain_rest.dto.diary.SecurityFoodForUpdateDTO;
 import com.dasd412.remake.api.domain.diary.EntityId;
 import com.dasd412.remake.api.domain.diary.diabetesDiary.DiabetesDiary;
 import com.dasd412.remake.api.domain.diary.diabetesDiary.DiaryRepository;
@@ -28,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.NoResultException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +41,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 수정 및 삭제 비즈니스 로직을 수행하는 서비스 클래스
  *
  * @author 양영준
- * @version 1.1.1 2022년 2월 28일
+ * @version 1.1.7 2022년 3월 23일
  */
 @Service
 public class UpdateDeleteDiaryService {
@@ -49,12 +53,103 @@ public class UpdateDeleteDiaryService {
     private final DiaryRepository diaryRepository;
     private final WriterRepository writerRepository;
 
-    public UpdateDeleteDiaryService(FoodRepository foodRepository, DietRepository dietRepository, DiaryRepository diaryRepository, WriterRepository writerRepository) {
+    private final SaveDiaryService saveDiaryService;
+
+    public UpdateDeleteDiaryService(FoodRepository foodRepository, DietRepository dietRepository, DiaryRepository diaryRepository, WriterRepository writerRepository, SaveDiaryService saveDiaryService) {
         this.foodRepository = foodRepository;
         this.dietRepository = dietRepository;
         this.diaryRepository = diaryRepository;
         this.writerRepository = writerRepository;
+        this.saveDiaryService = saveDiaryService;
     }
+
+    /**
+     * 일지 및 연관된 엔티티 수정 메서드
+     * 1.1.7부터 이것 사용할 것.
+     * @param principalDetails 사용자 인증 정보
+     * @param dto              일지 수정된 정보
+     * @return 수정된 일지
+     */
+    @Transactional
+    public Long updateDiaryWithEntities(PrincipalDetails principalDetails, SecurityDiaryUpdateDTO dto) {
+        logger.info("update diary in service logic");
+        checkNotNull(principalDetails, "principalDetails must be provided");
+
+        /* 0. 현재 세션에 담긴 사용자 정보 판별 */
+        Writer writer = writerRepository.findById(principalDetails.getWriter().getId()).orElseThrow(() -> new NoResultException("작성자가 없습니다."));
+
+        /* 1. 혈당 일지 변경 감지 되었으면 수정. */
+        Long diabetesDiaryId = dto.getDiaryId();
+        if (dto.isDiaryDirty()) {
+            DiabetesDiary targetDiary = diaryRepository.findOneDiabetesDiaryByIdInWriter(principalDetails.getWriter().getId(), diabetesDiaryId)
+                    .orElseThrow(() -> new NoResultException("해당 혈당일지가 존재하지 않습니다."));
+
+            targetDiary.update(dto.getFastingPlasmaGlucose(), dto.getRemark());
+        }
+
+        /* 2. 아침 식단 변경 감지 되었으면 수정 */
+        Long breakFastId = dto.getBreakFastId();
+
+        Diet targetBreakFast = dietRepository.findOneDietByIdInDiary(principalDetails.getWriter().getId(), diabetesDiaryId, breakFastId)
+                .orElseThrow(() -> new NoResultException("해당 아침 식단이 존재하지 않습니다."));
+        if (dto.isBreakFastDirty()) {
+            targetBreakFast.update(EatTime.BreakFast, dto.getBreakFastSugar());
+        }
+
+        /* 3. 점심 식단 변경 감지 되었으면 수정 */
+        Long lunchId = dto.getLunchId();
+
+        Diet targetLunch = dietRepository.findOneDietByIdInDiary(principalDetails.getWriter().getId(), diabetesDiaryId, lunchId)
+                .orElseThrow(() -> new NoResultException("해당 점심 식단이 존재하지 않습니다."));
+        if (dto.isLunchDirty()) {
+            targetLunch.update(EatTime.Lunch, dto.getLunchSugar());
+        }
+
+        /* 4. 저녁 식단 변경 감지 되었으면 수정 */
+        Long dinnerId = dto.getDinnerId();
+
+        Diet targetDinner = dietRepository.findOneDietByIdInDiary(principalDetails.getWriter().getId(), diabetesDiaryId, dinnerId)
+                .orElseThrow(() -> new NoResultException("해당 저녁 식단이 존재하지 않습니다."));
+
+        if (dto.isDinnerDirty()) {
+            targetDinner.update(EatTime.Dinner, dto.getDinnerSugar());
+        }
+
+        /* 5. 기존 음식 엔티티 삭제 ( in (id) 벌크 삭제) */
+        List<SecurityFoodForUpdateDTO> allOldFoods = new ArrayList<>();
+        allOldFoods.addAll(dto.getOldBreakFastFoods());
+        allOldFoods.addAll(dto.getOldLunchFoods());
+        allOldFoods.addAll(dto.getOldDinnerFoods());
+
+        if (allOldFoods.size() > 0) {
+            List<EntityId<Food, Long>> foodEntityIds = allOldFoods.stream().map(elem -> EntityId.of(Food.class, elem.getId())).collect(Collectors.toList());
+            bulkDeleteFoods(foodEntityIds);
+        }
+
+        /* 6. 음식 엔티티 새로이 생성 */
+        dto.getNewBreakFastFoods()
+                .forEach(elem -> {
+                    Food food = new Food(saveDiaryService.getNextIdOfFood(), targetBreakFast, elem.getFoodName(), elem.getAmount(), elem.getAmountUnit());
+                    targetBreakFast.addFood(food);
+                });
+
+        dto.getNewLunchFoods()
+                .forEach(elem -> {
+                    Food food = new Food(saveDiaryService.getNextIdOfFood(), targetLunch, elem.getFoodName(), elem.getAmount(), elem.getAmountUnit());
+                    targetLunch.addFood(food);
+                });
+
+        dto.getNewDinnerFoods()
+                .forEach(elem -> {
+                    Food food = new Food(saveDiaryService.getNextIdOfFood(), targetDinner, elem.getFoodName(), elem.getAmount(), elem.getAmountUnit());
+                    targetDinner.addFood(food);
+                });
+
+        writerRepository.save(writer);
+
+        return diabetesDiaryId;
+    }
+
 
     /**
      * 일지 내용 수정 메서드
@@ -184,17 +279,18 @@ public class UpdateDeleteDiaryService {
     }
 
     /**
-     * 프로필 수정 메서드 
+     * 프로필 수정 메서드
+     *
      * @param writerEntityId 래퍼로 감싸진 작성자 id
-     * @param phase 당뇨 단계
+     * @param phase          당뇨 단계
      * @return 수정된 프로필
      */
     @Transactional
-    public Profile updateProfile(EntityId<Writer, Long> writerEntityId, DiabetesPhase phase){
+    public Profile updateProfile(EntityId<Writer, Long> writerEntityId, DiabetesPhase phase) {
         logger.info("update profile");
         checkNotNull(writerEntityId, "writerId must be provided");
 
-        Profile targetProfile=writerRepository.findProfile(writerEntityId.getId()).orElseThrow(()->new NoResultException("프로필이 존재하지 않습니다."));
+        Profile targetProfile = writerRepository.findProfile(writerEntityId.getId()).orElseThrow(() -> new NoResultException("프로필이 존재하지 않습니다."));
 
         targetProfile.modifyDiabetesPhase(phase);
 

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -8,7 +8,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialec
 spring.jpa.hibernate.ddl-auto=update
 
 # jpa sql statistics
-# spring.jpa.properties.hibernate.generate_statistics=true
+spring.jpa.properties.hibernate.generate_statistics=true
 
 # profile include
 spring.profiles.include=oauth,database,email


### PR DESCRIPTION
트랜잭션 재배치로 일지 작성 및 수정에 있어서 성능 약 40% 향상.

(예시)
일지 1개 + 식사 3개 + 음식 15개에 대해 작성 시

이전 : 쿼리 77개

현재 : 쿼리 41개

